### PR TITLE
Updating and standardizing Python samples for Translator Text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Operating System files
+ .DS_Store
+ .gitignore
+Thumbs.db

--- a/BreakSentence.py
+++ b/BreakSentence.py
@@ -1,43 +1,44 @@
 # -*- coding: utf-8 -*-
 
-import http.client, urllib.parse, uuid, json
+# This simple app uses the '/breaksentence' resource to identify the source
+# language and determines the numbe of characters in each sentence.
 
-# **********************************************
-# *** Update or verify the following values. ***
-# **********************************************
+# This sample runs on Python 2.7.x and Python 3.x.
+# You may need to install requests and uuid.
+# Run: pip install requests uuid
 
-# Replace the subscriptionKey string value with your valid subscription key.
-subscriptionKey = 'ENTER KEY HERE'
 
-host = 'api.cognitive.microsofttranslator.com'
+import os, requests, uuid, json
+
+# Checks to see if the Translator Text subscription key is available
+# as an environment variable. If you are setting your subscription key as a
+# string, then comment these lines out.
+if 'TRANSLATOR_TEXT_KEY' in os.environ:
+    subscriptionKey = os.environ['TRANSLATOR_TEXT_KEY']
+else:
+    print('Environment variable for TRANSLATOR_TEXT_KEY is not set.')
+    exit()
+# If you want to set your subscription key as a string, uncomment the next line.
+#subscriptionKey = 'put_your_key_here'
+
+# If you encounter any issues with the base_url or path, make sure
+# that you are using the latest endpoint: https://docs.microsoft.com/azure/cognitive-services/translator/reference/v3-0-break-sentence
+base_url = 'https://api.cognitive.microsofttranslator.com'
 path = '/breaksentence?api-version=3.0'
-
 params = ''
+constructed_url = base_url + path + params
 
-text = 'How are you? I am fine. What did you do today?'
+headers = {
+    'Ocp-Apim-Subscription-Key': subscriptionKey,
+    'Content-type': 'application/json',
+    'X-ClientTraceId': str(uuid.uuid4())
+}
 
-def breakSentences (content):
-
-    headers = {
-        'Ocp-Apim-Subscription-Key': subscriptionKey,
-        'Content-type': 'application/json',
-        'X-ClientTraceId': str(uuid.uuid4())
-    }
-
-    conn = http.client.HTTPSConnection(host)
-    conn.request ("POST", path + params, content, headers)
-    response = conn.getresponse ()
-    return response.read ()
-
-requestBody = [{
-    'Text' : text,
+# You can pass more than one object in body.
+body = [{
+    'text': 'How are you? I am fine. What did you do today?'
 }]
-content = json.dumps(requestBody, ensure_ascii=False).encode('utf-8')
-result = breakSentences (content)
+request = requests.post(constructed_url, headers=headers, json=body)
+response = request.json()
 
-# Note: We convert result, which is JSON, to and from an object so we can pretty-print it.
-# We want to avoid escaping any Unicode characters that result contains. See:
-# https://stackoverflow.com/questions/18337407/saving-utf-8-texts-in-json-dumps-as-utf8-not-as-u-escape-sequence
-output = json.dumps(json.loads(result), indent=4, ensure_ascii=False)
-
-print (output)
+print(json.dumps(response, sort_keys=True, indent=4, ensure_ascii=False, separators=(',', ': ')))

--- a/BreakSentence.py
+++ b/BreakSentence.py
@@ -25,7 +25,7 @@ else:
 # that you are using the latest endpoint: https://docs.microsoft.com/azure/cognitive-services/translator/reference/v3-0-break-sentence
 base_url = 'https://api.cognitive.microsofttranslator.com'
 path = '/breaksentence?api-version=3.0'
-params = ''
+params = '&language=en'
 constructed_url = base_url + path + params
 
 headers = {

--- a/Detect.py
+++ b/Detect.py
@@ -1,43 +1,44 @@
 # -*- coding: utf-8 -*-
 
-import http.client, urllib.parse, uuid, json
+# This simple app uses the '/detect' resource to identify the language of
+# the provided text or texts.
 
-# **********************************************
-# *** Update or verify the following values. ***
-# **********************************************
+# This sample runs on Python 2.7.x and Python 3.x.
+# You may need to install requests and uuid.
+# Run: pip install requests uuid
 
-# Replace the subscriptionKey string value with your valid subscription key.
-subscriptionKey = 'ENTER KEY HERE'
 
-host = 'api.cognitive.microsofttranslator.com'
+import os, requests, uuid, json
+
+# Checks to see if the Translator Text subscription key is available
+# as an environment variable. If you are setting your subscription key as a
+# string, then comment these lines out.
+if 'TRANSLATOR_TEXT_KEY' in os.environ:
+    subscriptionKey = os.environ['TRANSLATOR_TEXT_KEY']
+else:
+    print('Environment variable for TRANSLATOR_TEXT_KEY is not set.')
+    exit()
+# If you want to set your subscription key as a string, uncomment the next line.
+#subscriptionKey = 'put_your_key_here'
+
+# If you encounter any issues with the base_url or path, make sure
+# that you are using the latest endpoint: https://docs.microsoft.com/azure/cognitive-services/translator/reference/v3-0-detect
+base_url = 'https://api.cognitive.microsofttranslator.com'
 path = '/detect?api-version=3.0'
-
 params = ''
+constructed_url = base_url + path + params
 
-text = 'Salve, mondo!'
+headers = {
+    'Ocp-Apim-Subscription-Key': subscriptionKey,
+    'Content-type': 'application/json',
+    'X-ClientTraceId': str(uuid.uuid4())
+}
 
-def detect (content):
-
-    headers = {
-        'Ocp-Apim-Subscription-Key': subscriptionKey,
-        'Content-type': 'application/json',
-        'X-ClientTraceId': str(uuid.uuid4())
-    }
-
-    conn = http.client.HTTPSConnection(host)
-    conn.request ("POST", path, content, headers)
-    response = conn.getresponse ()
-    return response.read ()
-
-requestBody = [{
-    'Text' : text,
+# You can pass more than one object in body.
+body = [{
+    'text': 'Salve, mondo!'
 }]
-content = json.dumps(requestBody, ensure_ascii=False).encode('utf-8')
-result = detect (content)
+request = requests.post(constructed_url, headers=headers, json=body)
+response = request.json()
 
-# Note: We convert result, which is JSON, to and from an object so we can pretty-print it.
-# We want to avoid escaping any Unicode characters that result contains. See:
-# https://stackoverflow.com/questions/18337407/saving-utf-8-texts-in-json-dumps-as-utf8-not-as-u-escape-sequence
-output = json.dumps(json.loads(result), indent=4, ensure_ascii=False)
-
-print (output)
+print(json.dumps(response, sort_keys=True, indent=4, ensure_ascii=False, separators=(',', ': ')))

--- a/Detect.py
+++ b/Detect.py
@@ -25,8 +25,7 @@ else:
 # that you are using the latest endpoint: https://docs.microsoft.com/azure/cognitive-services/translator/reference/v3-0-detect
 base_url = 'https://api.cognitive.microsofttranslator.com'
 path = '/detect?api-version=3.0'
-params = ''
-constructed_url = base_url + path + params
+constructed_url = base_url + path
 
 headers = {
     'Ocp-Apim-Subscription-Key': subscriptionKey,

--- a/DictionaryExample.py
+++ b/DictionaryExample.py
@@ -28,9 +28,6 @@ path = '/dictionary/examples?api-version=3.0'
 params = '&from=en&to=fr';
 constructed_url = base_url + path + params
 
-text = 'great'
-translation = 'formidable'
-
 headers = {
     'Ocp-Apim-Subscription-Key': subscriptionKey,
     'Content-type': 'application/json',

--- a/DictionaryExample.py
+++ b/DictionaryExample.py
@@ -1,45 +1,49 @@
 # -*- coding: utf-8 -*-
 
-import http.client, urllib.parse, uuid, json
+# This simple app uses the '/dictionary/examples' resource to illustrate
+# how terms in a dictionary are contexutalized.
 
-# **********************************************
-# *** Update or verify the following values. ***
-# **********************************************
+# This sample runs on Python 2.7.x and Python 3.x.
+# You may need to install requests and uuid.
+# Run: pip install requests uuid
 
-# Replace the subscriptionKey string value with your valid subscription key.
-subscriptionKey = 'ENTER KEY HERE'
 
-host = 'api.cognitive.microsofttranslator.com'
+import os, requests, uuid, json
+
+# Checks to see if the Translator Text subscription key is available
+# as an environment variable. If you are setting your subscription key as a
+# string, then comment these lines out.
+if 'TRANSLATOR_TEXT_KEY' in os.environ:
+    subscriptionKey = os.environ['TRANSLATOR_TEXT_KEY']
+else:
+    print('Environment variable for TRANSLATOR_TEXT_KEY is not set.')
+    exit()
+# If you want to set your subscription key as a string, uncomment the next line.
+#subscriptionKey = 'put_your_key_here'
+
+# If you encounter any issues with the base_url or path, make sure
+# that you are using the latest endpoint: https://docs.microsoft.com/azure/cognitive-services/translator/reference/v3-0-dictionary-examples
+base_url = 'https://api.cognitive.microsofttranslator.com'
 path = '/dictionary/examples?api-version=3.0'
-
 params = '&from=en&to=fr';
+constructed_url = base_url + path + params
 
 text = 'great'
 translation = 'formidable'
 
-def examples (content):
+headers = {
+    'Ocp-Apim-Subscription-Key': subscriptionKey,
+    'Content-type': 'application/json',
+    'X-ClientTraceId': str(uuid.uuid4())
+}
 
-    headers = {
-        'Ocp-Apim-Subscription-Key': subscriptionKey,
-        'Content-type': 'application/json',
-        'X-ClientTraceId': str(uuid.uuid4())
-    }
-
-    conn = http.client.HTTPSConnection(host)
-    conn.request ("POST", path + params, content, headers)
-    response = conn.getresponse ()
-    return response.read ()
-
-requestBody = [{
-    'Text' : text,
-    'Translation' : translation,
+# Each object takes two key/value pairs: 'text' and 'translation'.
+# Note: You can pass more than one object in body.
+body = [{
+    'text': 'great',
+    'translation': 'formidable'
 }]
-content = json.dumps(requestBody, ensure_ascii=False).encode('utf-8')
-result = examples (content)
+request = requests.post(constructed_url, headers=headers, json=body)
+response = request.json()
 
-# Note: We convert result, which is JSON, to and from an object so we can pretty-print it.
-# We want to avoid escaping any Unicode characters that result contains. See:
-# https://stackoverflow.com/questions/18337407/saving-utf-8-texts-in-json-dumps-as-utf8-not-as-u-escape-sequence
-output = json.dumps(json.loads(result), indent=4, ensure_ascii=False)
-
-print (output)
+print(json.dumps(response, sort_keys=True, indent=4, ensure_ascii=False, separators=(',', ': ')))

--- a/DictionaryLookup.py
+++ b/DictionaryLookup.py
@@ -22,7 +22,7 @@ else:
 #subscriptionKey = 'put_your_key_here'
 
 # If you encounter any issues with the base_url or path, make sure
-# that you are using the latest endpoint: https://docs.microsoft.com/azure/cognitive-services/translator/reference/v3-0-translate
+# that you are using the latest endpoint: https://docs.microsoft.com/azure/cognitive-services/translator/reference/v3-0-dictionary-lookup
 base_url = 'https://api.cognitive.microsofttranslator.com'
 path = '/dictionary/lookup?api-version=3.0'
 params = '&from=en&to=es';

--- a/DictionaryLookup.py
+++ b/DictionaryLookup.py
@@ -1,43 +1,44 @@
 # -*- coding: utf-8 -*-
 
-import http.client, urllib.parse, uuid, json
+# This simple app uses the '/dictionary/lookup' resource to return alternative
+# translations for a word and a small number of idiomatic phrases.
 
-# **********************************************
-# *** Update or verify the following values. ***
-# **********************************************
+# This sample runs on Python 2.7.x and Python 3.x.
+# You may need to install requests and uuid.
+# Run: pip install requests uuid
 
-# Replace the subscriptionKey string value with your valid subscription key.
-subscriptionKey = 'ENTER KEY HERE'
 
-host = 'api.cognitive.microsofttranslator.com'
+import os, requests, uuid, json
+
+# Checks to see if the Translator Text subscription key is available
+# as an environment variable. If you are setting your subscription key as a
+# string, then comment these lines out.
+if 'TRANSLATOR_TEXT_KEY' in os.environ:
+    subscriptionKey = os.environ['TRANSLATOR_TEXT_KEY']
+else:
+    print('Environment variable for TRANSLATOR_TEXT_KEY is not set.')
+    exit()
+# If you want to set your subscription key as a string, uncomment the next line.
+#subscriptionKey = 'put_your_key_here'
+
+# If you encounter any issues with the base_url or path, make sure
+# that you are using the latest endpoint: https://docs.microsoft.com/azure/cognitive-services/translator/reference/v3-0-translate
+base_url = 'https://api.cognitive.microsofttranslator.com'
 path = '/dictionary/lookup?api-version=3.0'
+params = '&from=en&to=es';
+constructed_url = base_url + path + params
 
-params = '&from=en&to=fr';
+headers = {
+    'Ocp-Apim-Subscription-Key': subscriptionKey,
+    'Content-type': 'application/json',
+    'X-ClientTraceId': str(uuid.uuid4())
+}
 
-text = 'great'
-
-def lookup (content):
-
-    headers = {
-        'Ocp-Apim-Subscription-Key': subscriptionKey,
-        'Content-type': 'application/json',
-        'X-ClientTraceId': str(uuid.uuid4())
-    }
-
-    conn = http.client.HTTPSConnection(host)
-    conn.request ("POST", path + params, content, headers)
-    response = conn.getresponse ()
-    return response.read ()
-
-requestBody = [{
-    'Text' : text,
+# You can pass more than one object in body.
+body = [{
+    'text': 'Elephants'
 }]
-content = json.dumps(requestBody, ensure_ascii=False).encode('utf-8')
-result = lookup (content)
+request = requests.post(constructed_url, headers=headers, json=body)
+response = request.json()
 
-# Note: We convert result, which is JSON, to and from an object so we can pretty-print it.
-# We want to avoid escaping any Unicode characters that result contains. See:
-# https://stackoverflow.com/questions/18337407/saving-utf-8-texts-in-json-dumps-as-utf8-not-as-u-escape-sequence
-output = json.dumps(json.loads(result), indent=4, ensure_ascii=False)
-
-print (output)
+print(json.dumps(response, sort_keys=True, indent=4, ensure_ascii=False, separators=(',', ': ')))

--- a/Languages.py
+++ b/Languages.py
@@ -1,35 +1,39 @@
-import http.client, urllib.parse, json
+# -*- coding: utf-8 -*-
 
-# **********************************************
-# *** Update or verify the following values. ***
-# **********************************************
+# This simple app performs a GET request to retrieve a list of languages
+# supported by Microsoft Translator.
 
-# Replace the subscriptionKey string value with your valid subscription key.
-subscriptionKey = '31b6016565ac4e1585b1fdb688e42c6d'
+# This sample runs on Python 2.7.x and Python 3.x.
+# You may need to install requests and uuid.
+# Run: pip install requests uuid
 
-host = 'api.cognitive.microsofttranslator.com'
+
+import os, requests, uuid, json
+
+# Checks to see if the Translator Text subscription key is available
+# as an environment variable. If you are setting your subscription key as a
+# string, then comment these lines out.
+if 'TRANSLATOR_TEXT_KEY' in os.environ:
+    subscriptionKey = os.environ['TRANSLATOR_TEXT_KEY']
+else:
+    print('Environment variable for TRANSLATOR_TEXT_KEY is not set.')
+    exit()
+# If you want to set your subscription key as a string, uncomment the next line.
+#subscriptionKey = 'put_your_key_here'
+
+# If you encounter any issues with the base_url or path, make sure
+# that you are using the latest endpoint: https://docs.microsoft.com/azure/cognitive-services/translator/reference/v3-0-languages
+base_url = 'https://api.cognitive.microsofttranslator.com'
 path = '/languages?api-version=3.0'
+constructed_url = base_url + path
 
-output_path = 'output.txt'
+headers = {
+    'Ocp-Apim-Subscription-Key': subscriptionKey,
+    'Content-type': 'application/json',
+    'X-ClientTraceId': str(uuid.uuid4())
+}
 
-def get_languages ():
+request = requests.get(constructed_url, headers=headers)
+response = request.json()
 
-    headers = {'Ocp-Apim-Subscription-Key': subscriptionKey}
-
-    conn = http.client.HTTPSConnection(host)
-    conn.request ("GET", path, None, headers)
-    response = conn.getresponse ()
-    return response.read ()
-
-result = get_languages ()
-
-# Note: We convert result, which is JSON, to and from an object so we can pretty-print it.
-# We want to avoid escaping any Unicode characters that result contains. See:
-# https://stackoverflow.com/questions/18337407/saving-utf-8-texts-in-json-dumps-as-utf8-not-as-u-escape-sequence
-json = json.dumps(json.loads(result), indent=4, ensure_ascii=False).encode('utf-8')
-
-print(json)
-
-f = open(output_path, 'wb')
-f.write (json)
-f.close
+print(json.dumps(response, sort_keys=True, indent=4, ensure_ascii=False, separators=(',', ': ')))

--- a/README.md
+++ b/README.md
@@ -30,3 +30,4 @@ This repository includes a sample for each of the methods made available by the 
 
 * [What is the Translator Text API?](https://docs.microsoft.com/azure/cognitive-services/translator/translator-info-overview)
 * [v3 Translator Text API Reference](https://docs.microsoft.com/azure/cognitive-services/translator/)
+* [Supported languages](https://docs.microsoft.com/azure/cognitive-services/translator/language-support)

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This repository includes Python code samples for Microsoft Translator. The sampl
 
 Here's what you'll need before you use these samples:
 
+* Your favorite IDE or text editor
 * Python 2.7.x or 3.x
 * An Azure subscription with Translator Text enabled. [Sign-up for a free account](https://docs.microsoft.com/azure/cognitive-services/translator/translator-text-how-to-signup)!
 
@@ -25,6 +26,7 @@ This repository includes a sample for each of the methods made available by the 
 * Set your subscription key.
 * Run the program. For example: `python Translate.py`.
 
-## Next steps
+## Resources
 
-* [v3 Translator Text API Reference](https://docs.microsoft.com/en-us/azure/cognitive-services/translator/)
+* [What is the Translator Text API?](https://docs.microsoft.com/azure/cognitive-services/translator/translator-info-overview)
+* [v3 Translator Text API Reference](https://docs.microsoft.com/azure/cognitive-services/translator/)

--- a/README.md
+++ b/README.md
@@ -1,17 +1,30 @@
-# Text-Translation-API-V3-Python
+# Translator Text API V3 - Python
+
+This repository includes Python code samples for Microsoft Translator. The samples are designed to run on Python 2.7.x and Python 3.x. Each sample corresponds to a **Quickstart** activity on [doc.microsoft.com](https://docs.microsoft.com/azure/cognitive-services/translator/), including:
+
+* [Translating text](https://docs.microsoft.com/azure/cognitive-services/translator/quickstart-python-translate)
+* [Transliterating text](https://docs.microsoft.com/azure/cognitive-services/translator/quickstart-python-transliterate)
+* [Identifying the language of source text](https://docs.microsoft.com/azure/cognitive-services/translator/quickstart-python-detect)
+* [Getting alternate translations](https://docs.microsoft.com/azure/cognitive-services/translator/quickstart-python-dictionary)
+* [Getting a complete list of supported languages](https://docs.microsoft.com/azure/cognitive-services/translator/quickstart-python-languages)
+* [Determining sentence length](https://docs.microsoft.com/azure/cognitive-services/translator/quickstart-python-sentences)
 
 ## Prerequisites
-You will need Python 3.x to run this code.
 
-You must have a Cognitive Services API account with Microsoft Translator Text API. You will need a paid subscription key from your Azure dashboard.
+Here's what you'll need before you use these samples:
 
+* Python 2.7.x or 3.x
+* An Azure subscription with Translator Text enabled. [Sign-up for a free account](https://docs.microsoft.com/azure/cognitive-services/translator/translator-text-how-to-signup)!
 
 ## Code samples
-The code in this repository contains examples for all of the Microsoft Text Translator V3 API methods. Each file demonstrates a single method. To try out a method:
 
-#### Create a new Python project in your favorite IDE.
-#### Add the provided code.
-#### Replace the key value with an access key valid for your subscription.
-#### Run the program.
+This repository includes a sample for each of the methods made available by the Microsoft Translator Text API v3. To use each of the samples, follow these instructions:
 
-[Translator Text API Reference](https://docs.microsoft.com/en-us/azure/cognitive-services/translator/)
+* Create a new project in your favorite IDE or editor.
+* Copy the code from one of the samples into your project.
+* Set your subscription key.
+* Run the program. For example: `python Translate.py`.
+
+## Next steps
+
+* [v3 Translator Text API Reference](https://docs.microsoft.com/en-us/azure/cognitive-services/translator/)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Translator Text API V3 - Python
+# Translator Text API V3 - Python Samples
 
 This repository includes Python code samples for Microsoft Translator. The samples are designed to run on Python 2.7.x and Python 3.x. Each sample corresponds to a **Quickstart** activity on [doc.microsoft.com](https://docs.microsoft.com/azure/cognitive-services/translator/), including:
 

--- a/Translate.py
+++ b/Translate.py
@@ -1,8 +1,12 @@
 # -*- coding: utf-8 -*-
 
+# This simple app uses the '/translate' resource to transliterate text from
+# one language to another.
+
 # This sample runs on Python 2.7.x and Python 3.x.
 # You may need to install requests and uuid.
 # Run: pip install requests uuid
+
 import os, requests, uuid, json
 
 # Checks to see if the Translator Text subscription key is available

--- a/Transliterate.py
+++ b/Transliterate.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # This simple app uses the '/transliterate' resource to transliterate text from
-# one script to another. In this sample, Japenese is transliterated to use the
+# one script to another. In this sample, Japanese is transliterated to use the
 # Latin alphabet.
 
 # This sample runs on Python 2.7.x and Python 3.x.

--- a/Transliterate.py
+++ b/Transliterate.py
@@ -1,45 +1,46 @@
 # -*- coding: utf-8 -*-
 
-import http.client, urllib.parse, uuid, json
+# This simple app uses the '/transliterate' resource to transliterate text from
+# one script to another. In this sample, Japenese is transliterated to use the
+# Latin alphabet.
 
-# **********************************************
-# *** Update or verify the following values. ***
-# **********************************************
+# This sample runs on Python 2.7.x and Python 3.x.
+# You may need to install requests and uuid.
+# Run: pip install requests uuid
 
-# Replace the subscriptionKey string value with your valid subscription key.
-subscriptionKey = 'ENTER KEY HERE'
 
-host = 'api.cognitive.microsofttranslator.com'
+import os, requests, uuid, json
+
+# Checks to see if the Translator Text subscription key is available
+# as an environment variable. If you are setting your subscription key as a
+# string, then comment these lines out.
+if 'TRANSLATOR_TEXT_KEY' in os.environ:
+    subscriptionKey = os.environ['TRANSLATOR_TEXT_KEY']
+else:
+    print('Environment variable for TRANSLATOR_TEXT_KEY is not set.')
+    exit()
+# If you want to set your subscription key as a string, uncomment the next line.
+#subscriptionKey = 'put_your_key_here'
+
+# If you encounter any issues with the base_url or path, make sure
+# that you are using the latest endpoint: https://docs.microsoft.com/azure/cognitive-services/translator/reference/v3-0-transliterate
+base_url = 'https://api.cognitive.microsofttranslator.com'
 path = '/transliterate?api-version=3.0'
+params = '&language=ja&fromScript=jpan&toScript=latn'
+constructed_url = base_url + path + params
 
-# Transliterate text in Japanese from Japanese script (i.e. Hiragana/Katakana/Kanji) to Latin script.
-params = '&language=ja&fromScript=jpan&toScript=latn';
+headers = {
+    'Ocp-Apim-Subscription-Key': subscriptionKey,
+    'Content-type': 'application/json',
+    'X-ClientTraceId': str(uuid.uuid4())
+}
 
-# Transliterate "good afternoon".
-text = 'こんにちは'
-
-def transliterate (content):
-
-    headers = {
-        'Ocp-Apim-Subscription-Key': subscriptionKey,
-        'Content-type': 'application/json',
-        'X-ClientTraceId': str(uuid.uuid4())
-    }
-
-    conn = http.client.HTTPSConnection(host)
-    conn.request ("POST", path + params, content, headers)
-    response = conn.getresponse ()
-    return response.read ()
-
-requestBody = [{
-    'Text' : text,
+# Transliterate "good afternoon" from source Japanese.
+# Note: You can pass more than one object in body.
+body = [{
+    'text': 'こんにちは'
 }]
-content = json.dumps(requestBody, ensure_ascii=False).encode('utf-8')
-result = transliterate (content)
+request = requests.post(constructed_url, headers=headers, json=body)
+response = request.json()
 
-# Note: We convert result, which is JSON, to and from an object so we can pretty-print it.
-# We want to avoid escaping any Unicode characters that result contains. See:
-# https://stackoverflow.com/questions/18337407/saving-utf-8-texts-in-json-dumps-as-utf8-not-as-u-escape-sequence
-output = json.dumps(json.loads(result), indent=4, ensure_ascii=False)
-
-print (output)
+print(json.dumps(response, sort_keys=True, indent=4, ensure_ascii=False, separators=(',', ': ')))


### PR DESCRIPTION
* Works with Python 2.7.x and 3.x.
* Updated all samples to use the `requests` module
* Standardized the way calls are constructed
* Added support for environment variables or hard coded keys
* Updated the README.md with new introduction, links, and instructions. 

@Jann-Skotdal @kellyaltom 